### PR TITLE
!HotFix: SecurityConfig 순환 참조 오류 수정

### DIFF
--- a/src/main/java/com/v1/matripserver/auth/JwtTokenFilter.java
+++ b/src/main/java/com/v1/matripserver/auth/JwtTokenFilter.java
@@ -6,7 +6,6 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -18,11 +17,15 @@ import java.io.IOException;
 import java.util.List;
 
 // OncePerRequestFilter : 매번 들어갈 때 마다 체크 해주는 필터
-@RequiredArgsConstructor
 public class JwtTokenFilter extends OncePerRequestFilter {
 
     private final MemberService memberService;
     private final String secretKey;
+
+    public JwtTokenFilter(MemberService memberService, String secretKey) {
+        this.memberService = memberService;
+        this.secretKey = secretKey;
+    }
 
     @Override
     protected void doFilterInternal(

--- a/src/main/java/com/v1/matripserver/auth/PasswordEncoderConfig.java
+++ b/src/main/java/com/v1/matripserver/auth/PasswordEncoderConfig.java
@@ -1,0 +1,14 @@
+package com.v1.matripserver.auth;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/v1/matripserver/config/SecurityConfig.java
+++ b/src/main/java/com/v1/matripserver/config/SecurityConfig.java
@@ -33,11 +33,6 @@ public class SecurityConfig{
     private static String secretKey = "test001";
 
     @Bean
-    public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
-    }
-
-    @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
         return http


### PR DESCRIPTION
## Motivation:

- 순환 참조 오류로 인한, 서버 작동 오류

## Modifications:

- PasswordEncoder 메서드를 SecurityConfig에서 분리

## Result:

- 서버 작동 오류 수정 완료 -> 정상 작동
