### PR TITLE
[PR] 사용자 조회 순환 참조 오류 수정

### DIFF
--- a/src/main/java/com/v1/matripserver/member/entity/Member.java
+++ b/src/main/java/com/v1/matripserver/member/entity/Member.java
@@ -50,10 +50,10 @@ public class Member extends BaseEntity {
     @Column(name = "auth", nullable = false)
     private Auth auth;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<MemberLink> memberLinkList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, fetch = FetchType.EAGER)
     private List<MemberProfile> memberProfileList = new ArrayList<>();
 
     public void setNickname(String nickname) {

--- a/src/main/java/com/v1/matripserver/member/entity/MemberLink.java
+++ b/src/main/java/com/v1/matripserver/member/entity/MemberLink.java
@@ -1,5 +1,6 @@
 package com.v1.matripserver.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.v1.matripserver.util.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -16,8 +17,9 @@ public class MemberLink {
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @JsonIgnore
     private Member member;
 
     @Column(name = "path", nullable = false)

--- a/src/main/java/com/v1/matripserver/member/entity/MemberProfile.java
+++ b/src/main/java/com/v1/matripserver/member/entity/MemberProfile.java
@@ -1,5 +1,6 @@
 package com.v1.matripserver.member.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.v1.matripserver.util.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -16,8 +17,9 @@ public class MemberProfile {
     @Column(name = "id", nullable = false, updatable = false)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
+    @JsonIgnore
     private Member member;
 
     @Column(name = "path", nullable = false)

--- a/src/main/java/com/v1/matripserver/member/service/MemberService.java
+++ b/src/main/java/com/v1/matripserver/member/service/MemberService.java
@@ -23,6 +23,7 @@ public interface MemberService {
     ResponseDto.MemberDto getMyPageById(Long memberId);
 
     void updateMember(Long memberId, RequestDto.UpdateMemberDto updateMemberDto);
+
     void addProfile(Long memberId, AddProfileDto addProfileDto);
 
     void addLink(Long memberId, AddLinkDto addLinkDto);


### PR DESCRIPTION

## Motivation:

- 사용자 프로필 추가 후 사용자 정보 조회 시 순환 참조 오류가 나는 부분을 수정합니다.


## Modifications:

- Member에서 MemberProfile과 MemberLink를 EAGER방식으로 가져옵니다.
- MemberProfile과 MemberLink는 Lazy방식으로 가져옵니다.
- MemberProfile과 MemberLink에 Member를 참조하는 부분에 JsonIgnore를 사용하여, 참조를 끊습니다.

## Result:

- 이제 사용자 프로필 추가 후 정상적으로 사용자 정보를 조회합니다.
